### PR TITLE
Fix Maven publication configuration

### DIFF
--- a/thumbprint/build.gradle.kts
+++ b/thumbprint/build.gradle.kts
@@ -155,9 +155,30 @@ afterEvaluate {
     publishing {
         publications {
             create<MavenPublication>("release") {
-                groupId = "com.github.thumbtack"
-                artifactId = "thumbprint"
-                version = "1.1.0"
+                groupId = project.group.toString()
+                artifactId = "thumbprint-android"
+                version = project.version.toString()
+
+                from(components["release"])
+
+                pom {
+                    name.set("Thumbprint")
+                    description.set("Assets for building high-quality, consistent user experiences at Thumbtack.")
+                    url.set("https://thumbprint.design/")
+
+                    licenses {
+                        license {
+                            name.set("Apache License 2.0")
+                            url.set("https://github.com/thumbtack/thumbprint-android/blob/main/LICENSE")
+                        }
+                    }
+
+                    scm {
+                        connection.set("scm:git:git://github.com:thumbtack/thumbprint-android.git")
+                        developerConnection.set("scm:git:ssh://github.com:thumbtack/thumbprint-android.git")
+                        url.set("https://github.com/thumbtack/thumbprint-android")
+                    }
+                }
             }
         }
     }

--- a/thumbprint/proguard-rules.pro
+++ b/thumbprint/proguard-rules.pro
@@ -1,11 +1,13 @@
 # For more details, see
 #   http://developer.android.com/guide/developing/tools/proguard.html
 
-# Add any project specific keep options here:
+# keep all public classes, otherwise they will be removed by tree-shaking since they may be unused within this library
+-keep public class com.thumbtack.thumbprint.** {
+  # also keep all public methods; this is necessary to keep file-level functions
+  public <methods>;
 
-# If your project uses WebView with JS, uncomment the following
-# and specify the fully qualified class name to the JavaScript interface
-# class:
-#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
-#   public *;
-#}
+  # also keep the companion object class; this appears to be necessary to reference companion object functions
+  # statically (i.e. MyClass.foo() rather than MyClass.Companion.foo()), although it's not entirely clear why
+  # See: https://jakewharton.com/r8-optimization-staticization/
+  public static ** Companion;
+}


### PR DESCRIPTION
Fix a few issues with the gradle configuration to publish Maven artifacts:
- add from() directive, so that an AAR is actually generated. Before, there was
  no component supplying files so only a POM file was included in the release
- use groupId and version from the gradle project, to avoid duplication
- fix the artifactId to be thumbprint-android
- add more metadata to the POM file, including links and a license. This is
  mostly inspired by
  https://docs.gradle.org/current/userguide/publishing_maven.html#sec:modifying_the_generated_pom
- fix the ProGuard configuration to avoid it stripping all code from the AAR,
  which was happening before since there are no external usages of our classes.
  We could also disable minification since it probably doesn't do much for us,
  or use the debug component, but keeping D8 in case we ever do have any truly
  unused code might be handy.

Verified by publishing to the local Maven repo and building the Thumbtack apps
from that, which worked.