### PR TITLE
HG-327 Fix crash when passing empty initials to BlankAvatarDrawable

### DIFF
--- a/thumbprint/src/main/java/com/thumbtack/thumbprint/BlankAvatarDrawable.kt
+++ b/thumbprint/src/main/java/com/thumbtack/thumbprint/BlankAvatarDrawable.kt
@@ -105,11 +105,11 @@ internal class BlankAvatarDrawable(
     }
 
     private fun setColorsFromInitials(initials: String?) {
-        if (initials == null) {
+        val hash = initials?.firstOrNull()?.toInt()
+        if (hash == null) {
             backgroundColor = ContextCompat.getColor(context, R.color.tp_gray_200)
             textColor = ContextCompat.getColor(context, R.color.tp_black)
         } else {
-            val hash = initials.first().toInt()
             backgroundColor = backgroundColors[hash % backgroundColors.size]
             textColor = textColors[hash % textColors.size]
         }


### PR DESCRIPTION
BlankAvatarDrawable throws exception if empty initials are passed to view:

`java.util.NoSuchElementException: Char sequence is empty.at kotlin.text.StringsKt___StringsKt.first(_Strings.kt:71)at com.thumbtack.thumbprint.BlankAvatarDrawable.setColorsFromInitials(BlankAvatarDrawable.kt:112)at com.thumbtack.thumbprint.BlankAvatarDrawable.setText(BlankAvatarDrawable.kt:42)`