### PR TITLE
ThumbprintButton: Add support to set left and right drawables programatically

### DIFF
--- a/thumbprint/src/main/java/com/thumbtack/thumbprint/views/button/ThumbprintButton.kt
+++ b/thumbprint/src/main/java/com/thumbtack/thumbprint/views/button/ThumbprintButton.kt
@@ -8,6 +8,8 @@ import android.graphics.Typeface.BOLD
 import android.graphics.drawable.Drawable
 import android.os.Build
 import android.util.AttributeSet
+import androidx.annotation.DimenRes
+import androidx.annotation.DrawableRes
 import androidx.appcompat.view.ContextThemeWrapper
 import androidx.appcompat.widget.AppCompatButton
 import androidx.core.content.ContextCompat
@@ -227,5 +229,37 @@ class ThumbprintButton @JvmOverloads constructor(
             PorterDuffColorFilter(loadingAnimationColor, PorterDuff.Mode.SRC_ATOP)
 
         setTextColor(ContextCompat.getColorStateList(context, buttonType.textColorStateListId))
+    }
+
+    /**
+     * Set the drawable to be displayed on the left of the Button title.
+     * The drawable will have the same tint than the button's title.
+     * NOTE: If there's already a drawable assigned to the button via XML, then this method won't
+     * have any effect.
+     */
+    fun setInlineDrawableLeft(
+        @DrawableRes drawableResource: Int?,
+        @DimenRes drawablePadding: Int? = null
+    ) {
+        withDrawableAttributes.apply {
+            fallbackInlineDrawableLeftResId = drawableResource
+            fallbackInlineDrawablePaddingRes = drawablePadding
+        }
+    }
+
+    /**
+     * Set the drawable to be displayed on the right of the Button title.
+     * The drawable will have the same tint than the button's title.
+     * NOTE: If there's already a drawable assigned to the button via XML, then this method won't
+     * have any effect.
+     */
+    fun setInlineDrawableRight(
+        @DrawableRes drawableResource: Int?,
+        @DimenRes drawablePadding: Int? = null
+    ) {
+        withDrawableAttributes.apply {
+            fallbackInlineDrawableRightResId = drawableResource
+            fallbackInlineDrawablePaddingRes = drawablePadding
+        }
     }
 }


### PR DESCRIPTION
## What

There's currently no available way to programmatically set the left or right inline drawable on the button. We can do it via `XML` using the `inlineDrawableLeft` attribute, but if the icon comes from the BE for example, then we are stuck. 
This feature could be really useful now that the `Cta` backend model has `Icons` within it. 

## How

Adds 2 methods that use the `fallbackInlineDrawableLeftResId` parameter from the `WithDrawableAttributes` to set the drawable. This will trigger the text to be reset, which will call the `getDrawableIfDefined` method from `WithDrawableAttributes` and load the asset properly. 

**Note:** This proposed solution is based from how the current `ButtonWithDrawables` class in the Android Punk app works. It is important to note that because it uses the `fallbackResId`, if an icon is already set via XML, the method won't do anything. I added a comment on the method to highlight that. 

## Testing

I tested it myself using the local maven repo, and it is working as expected.
